### PR TITLE
Add note to enable compiler if missing

### DIFF
--- a/Basics/1_Load_and_compile/README.md
+++ b/Basics/1_Load_and_compile/README.md
@@ -10,6 +10,6 @@ Load a file from the files explorer.
 
 5. Click ballot.sol & the file should appear in the main panel in a tab.
 
-7. Click the solidity compiler icon ![solidity compiler icon](https://github.com/ethereum/remix-workshops/blob/master/Basics/1_Load_and_compile/images/solidity.png?raw=true "solidity compiler icon") - in the icon panel.
+7. Click the solidity compiler icon ![solidity compiler icon](https://github.com/ethereum/remix-workshops/blob/master/Basics/1_Load_and_compile/images/solidity.png?raw=true "solidity compiler icon") - in the icon panel. (If you do not see the icon in the sidebar find and activate the "Solidity Compiler" module.)
 
 8. Click the compile button ![compile ballot](https://github.com/ethereum/remix-workshops/blob/master/Basics/1_Load_and_compile/images/compile-ballot.png?raw=true "compile ballot") and watch it compile - or at least watch the spinner spin.


### PR DESCRIPTION
In my experience when I activated the solidity environment the ide did not enable the solidity compiler plugin. This PR fixes the issue.