### PR TITLE
Name contract for Pragma step of intro

### DIFF
--- a/Solidity-intro/1_Pragma/pragma.sol
+++ b/Solidity-intro/1_Pragma/pragma.sol
@@ -1,3 +1,3 @@
 
-contract contract {
+contract SimpleStorage {
 }


### PR DESCRIPTION
The very first step of the intro results in compiler errors because the contract is named `contract`, a keyword.