### PR TITLE
Fix wrong name of contract in answer

### DIFF
--- a/Solidity-intro/1_Pragma/pragma_answer.sol
+++ b/Solidity-intro/1_Pragma/pragma_answer.sol
@@ -1,3 +1,3 @@
 pragma solidity >=0.4.0 <0.7.0;
-contract contract {
+contract SimpleStorage {
 }


### PR DESCRIPTION
The name of the contract in the answer should be "SimpleStorage" instead of "contract" as indicated in the question.