### PR TITLE
Course fixes

### DIFF
--- a/ERC20TokenCourse/README.md
+++ b/ERC20TokenCourse/README.md
@@ -1,5 +1,5 @@
 ## Interactive Solidity Token Course
 
-Learn to understand and create your ERC20 and ERC721 (NFT) tokens.
+Learn to understand and create ERC20 tokens.
 
 Developed by the p2p learning platform https://dacade.org.

--- a/NFTTokenCourse/erc721-token-creation/erc721TokenCreation_answer.sol
+++ b/NFTTokenCourse/erc721-token-creation/erc721TokenCreation_answer.sol
@@ -8,7 +8,7 @@ contract Geometry is ERC721, Ownable {
     constructor() ERC721("Geometry", "GEO") {}
 
     function _baseURI() internal pure override returns (string memory) {
-        return "https://ipfs.io/ipfs/QmSw9o2dDbGSK8BGHB1yYZDCzBfAjKtv5DFebQadJUZb85/";
+        return "https://ipfs.io/ipfs/QmVrsYxXh5PzTfkKZr1MfUN6PotJj8VQkGQ3kGyBNVKtqp/";
     }
 
     function safeMint(address to, uint256 tokenId) public onlyOwner {

--- a/NFTTokenCourse/erc721-token-creation/erc721TokenCreation_test.sol
+++ b/NFTTokenCourse/erc721-token-creation/erc721TokenCreation_test.sol
@@ -20,6 +20,6 @@ contract MyTest is Geometry {
 
     function checkMint() payable public returns (bool) {
         safeMint(acc0,0);
-        return Assert.equal(tokenURI(0), string("https://ipfs.io/ipfs/QmSw9o2dDbGSK8BGHB1yYZDCzBfAjKtv5DFebQadJUZb85/0"), "Wrong tokenURI");
+        return Assert.equal(tokenURI(0), string("https://ipfs.io/ipfs/QmVrsYxXh5PzTfkKZr1MfUN6PotJj8VQkGQ3kGyBNVKtqp/0"), "Wrong tokenURI");
     }
 }


### PR DESCRIPTION
Includes two fixes:

### 1. Fix tokenURI in NFT course
The tokenURI described in the exercise did not match with the one that we show in the answer and that we test for. This PR fixes that.
Reported here: https://twitter.com/MacbookairM/status/1519052933777698823

### 3.  Fix description of ERC20 token course
The wording in the course description suggests that we also cover ERC721 in this course, which we don't do. This PR fixes that.
