### PR TITLE
Update etherAndWei.md

### DIFF
--- a/SolidityBeginnerCourse/transactions-ether-and-wei/etherAndWei.md
+++ b/SolidityBeginnerCourse/transactions-ether-and-wei/etherAndWei.md
@@ -15,7 +15,7 @@ One `ether` is equal to 1,000,000,000,000,000,000 (10^18) `wei` (line 11).
 <a href="https://www.youtube.com/watch?v=ybPQsjssyNw" target="_blank">Watch a video tutorial on Ether and Wei</a>.
 
 ## ⭐️ Assignment
-1. Create a `public` `uint` called `oneGWei` and set it to 1 `gwei`.
-2. Create a `public` `bool` called `isOneGWei` and set it to the result of a comparison operation between 1 gwei and 10^9.
+1. Create a `public` `uint` called `oneGwei` and set it to 1 `gwei`.
+2. Create a `public` `bool` called `isOneGwei` and set it to the result of a comparison operation between 1 gwei and 10^9.
 
 Tip: Look at how this is written for `gwei` and `ether` in the contract.


### PR DESCRIPTION
Fix the typo.

[etherAndWei_test.sol](https://github.com/ethereum/remix-workshops/blob/master/SolidityBeginnerCourse/transactions-ether-and-wei/etherAndWei_test.sol)

The test is calling `foo.oneGwei()` here and didn't match the varible name `oneGWei`.

