### PR TITLE
Fix issue #145: Correct error message and update modifiersAndConstructors_answer.sol

### DIFF
--- a/SolidityBeginnerCourse/functions-modifiers-and-constructors/modifiersAndConstructors_answer.sol
+++ b/SolidityBeginnerCourse/functions-modifiers-and-constructors/modifiersAndConstructors_answer.sol
@@ -35,7 +35,7 @@ contract FunctionModifier {
     }
     
     modifier biggerThan0(uint y) {
-        require(y > 0, "Not bigger than x");
+        require(y > 0, "Not bigger than 0");
         _;
     }
     


### PR DESCRIPTION
This pull request addresses a minor improvement in the contract's codebase by updating the error message in the biggerThan0 modifier. The current message, "Not bigger than x," is being modified to "Not bigger than 0" for greater clarity.

Testing:
Confirmed that the updated error message is triggered when the requirement of the biggerThan0 modifier is not met (i.e., when y is not greater than 0).
Feedback and suggestions are welcomed.