### PR TITLE
Typo: Line number mismatches in erc20-weth-interfaces.md

### DIFF
--- a/Uniswap-Tutorial/5-erc20-weth-interfaces/erc20-weth-interfaces.md
+++ b/Uniswap-Tutorial/5-erc20-weth-interfaces/erc20-weth-interfaces.md
@@ -3,25 +3,25 @@ In this section, we'll explore the `IERC20` interface, a standard interface for 
 You can find a "Solidity ERC20 Token Course" for beginners in LearnEth to understand the ERC20 token standard in more detail.
 
 ## IERC20 Interface
-On line 80, we define the `IERC20` interface. This interface defines a standard set of functions that ERC-20 tokens must implement. Let's examine the key functions within this interface:
+On line 85, we define the `IERC20` interface. This interface defines a standard set of functions that ERC-20 tokens must implement. Let's examine the key functions within this interface:
 
 ### 1. totalSupply
-On line 81, we define the `totalSupply` function. This function returns the total supply of the token.
+On line 86, we define the `totalSupply` function. This function returns the total supply of the token.
 
 ### 2. balanceOf
-On line 83, we define the `balanceOf` function. This function returns the balance of the specified address.
+On line 88, we define the `balanceOf` function. This function returns the balance of the specified address.
 
 ### 3. transfer
-On line 85, we define the `transfer` function. This function transfers tokens from the sender to the specified recipient.
+On line 90, we define the `transfer` function. This function transfers tokens from the sender to the specified recipient.
 
 ### 4. allowance
-On line 87, we define the `allowance` function. This function returns the amount of tokens that the spender is allowed to spend on behalf of the owner.
+On line 92, we define the `allowance` function. This function returns the amount of tokens that the spender is allowed to spend on behalf of the owner.
 
 ### 5. approve
-On line 89, we define the `approve` function. When called, this function approves a spender to spend the specified amount of tokens on behalf of the sender.
+On line 94, we define the `approve` function. When called, this function approves a spender to spend the specified amount of tokens on behalf of the sender.
 
 ### 6. transferFrom
-On line 91, we define the `transferFrom` function. This function transfers tokens from the specified sender to the recipient. The function can only be called by the spender if the spender is allowed to spend the specified amount of tokens on behalf of the sender.
+On line 96, we define the `transferFrom` function. This function transfers tokens from the specified sender to the recipient. The function can only be called by the spender if the spender is allowed to spend the specified amount of tokens on behalf of the sender.
 
 ### 7. Events
 On lines 102-103, we define the `Transfer` and `Approval` events. These events are emitted when the `transfer` and `approve` functions are called, respectively.


### PR DESCRIPTION
There are several line number typos in erc20-weth-interfaces.md

https://github.com/ethereum/remix-workshops/blob/master/Uniswap-Tutorial/5-erc20-weth-interfaces/erc20-weth-interfaces.md?plain=1#L8-L24

https://github.com/ethereum/remix-workshops/blob/master/Uniswap-Tutorial/5-erc20-weth-interfaces/erc20-weth-interfaces.sol#L85C1-L101C1
